### PR TITLE
Change bash script shebangs to use env

### DIFF
--- a/utilities/imgcat
+++ b/utilities/imgcat
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 

--- a/utilities/imgls
+++ b/utilities/imgls
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It
 # only accepts ESC backslash for ST.

--- a/utilities/it2attention
+++ b/utilities/it2attention
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It

--- a/utilities/it2check
+++ b/utilities/it2check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Make sure stdin and stdout are a tty.
 if [ ! -t 0 ] ; then
   exit 1

--- a/utilities/it2copy
+++ b/utilities/it2copy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 trap clean_up EXIT
 trap clean_up INT

--- a/utilities/it2dl
+++ b/utilities/it2dl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ $# -lt 1 ]; then
   echo "Usage: $(basename $0) file ..."
   exit 1

--- a/utilities/it2getvar
+++ b/utilities/it2getvar
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It

--- a/utilities/it2git
+++ b/utilities/it2git
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script sets iTerm2 user-defined variables describing the state of the git
 # repo in the current directory.
 #

--- a/utilities/it2profile
+++ b/utilities/it2profile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 

--- a/utilities/it2setcolor
+++ b/utilities/it2setcolor
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 open=0
 
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;

--- a/utilities/it2setkeylabel
+++ b/utilities/it2setkeylabel
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It
@@ -32,7 +32,7 @@ function show_help() {
     echo "     If name is given, all key labels up to and including the one with the matching name are popped." 1>& 2
     echo "" 1>& 2
     echo "Example:" 1>& 2
-    echo "#!/bin/bash" 1>& 2
+    echo "#!/usr/bin/env bash" 1>& 2
     echo "# Wrapper script for mc that sets function key labels" 1>& 2
     echo "NAME=mc_\$RANDOM" 1>& 2
     echo "# Save existing labels" 1>& 2

--- a/utilities/it2ul
+++ b/utilities/it2ul
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 trap clean_up EXIT
 _STTY=$(stty -g)      ## Save current terminal setup

--- a/utilities/it2universion
+++ b/utilities/it2universion
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It


### PR DESCRIPTION
This allows the scripts to work on BSD systems, which don't have bash in the base system, and install third-party software in /usr/local.

It will also use a MacPorts or Homebrew-installed bash on Mac OS, if it's earlier in the user's path than the system bash.  On a 10.14 machine, Homebrew-installed bash was about twice as fast to imgcat a 5MB png, compared to the system bash.