### PR TITLE
Change it2api shebang to python3 from python3.7

### DIFF
--- a/utilities/it2api
+++ b/utilities/it2api
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 
 import argparse
 import asyncio


### PR DESCRIPTION
I think this was an oversight?  Mac OS users with Python 3 installed are likely to have 3.9 or 3.10 at this point.