### PR TITLE
Consume pending input before parsing DSR info.

### DIFF
--- a/utilities/it2check
+++ b/utilities/it2check
@@ -43,21 +43,14 @@ function clean_up() {
   stty "$_STTY"            ## Restore terminal settings
 }
 
-# Consume any pending input on stdin, which would otherwise be accidentally
-# consumed by `read_dsr`, which would attempt and fail to parse it as DSR
-# version information.
-# For `iTerm.app`, this results in `it2check` incorrectly returning false.
-# For e.g. `Terminal.app`, this makes `it2check` hang (until an `n` is entered).
-# TODO: Ideally, we would be able to capture the DSR response without destroying
-# the existing pending input. However, simple workarounds (such as executing
-# `$(it2check)` in a subshell) don't work (because the DSR response is not
-# generated from a subshell).
-stty -echo -icanon raw min 0 time 0  # Prepare to silently read any (>=0) characters with no timeout.
-while read none; do :; done  # Consume all pending input (on stdin).
-clean_up  # Reset the TTY, so it behaves as expected for the rest of the it2check script.
-# NOTE: Any future input at the terminal before `read_dsr` causes `it2check` to fail.
-# For example, uncomment the following line and enter characters to see it fail.
-# echo "Enter any non-DSR characters in the next two seconds..."; sleep 2
+# Prepare to silently read any (>=0) characters with no timeout.
+stty -echo -icanon raw min 0 time 0
+
+# Consume all pending input.
+while read none; do :; done
+
+# Reset the TTY, so it behaves as expected for the rest of the it2check script.
+clean_up 
 
 # Enter raw mode and turn off echo so the terminal and I can chat quietly.
 stty -echo -icanon raw

--- a/utilities/it2check
+++ b/utilities/it2check
@@ -43,6 +43,22 @@ function clean_up() {
   stty "$_STTY"            ## Restore terminal settings
 }
 
+# Consume any pending input on stdin, which would otherwise be accidentally
+# consumed by `read_dsr`, which would attempt and fail to parse it as DSR
+# version information.
+# For `iTerm.app`, this results in `it2check` incorrectly returning false.
+# For e.g. `Terminal.app`, this makes `it2check` hang (until an `n` is entered).
+# TODO: Ideally, we would be able to capture the DSR response without destroying
+# the existing pending input. However, simple workarounds (such as executing
+# `$(it2check)` in a subshell) don't work (because the DSR response is not
+# generated from a subshell).
+stty -echo -icanon raw min 0 time 0  # Prepare to silently read any (>=0) characters with no timeout.
+while read none; do :; done  # Consume all pending input (on stdin).
+clean_up  # Reset the TTY, so it behaves as expected for the rest of the it2check script.
+# NOTE: Any future input at the terminal before `read_dsr` causes `it2check` to fail.
+# For example, uncomment the following line and enter characters to see it fail.
+# echo "Enter any non-DSR characters in the next two seconds..."; sleep 2
+
 # Enter raw mode and turn off echo so the terminal and I can chat quietly.
 stty -echo -icanon raw
 


### PR DESCRIPTION
Currently, the `it2check` utility either (returns an incorrect value or causes the terminal application to hang) if there is pending input on stdin. This can happen in any number of ways, but I encountered it when `it2check` was being run as part of a larger script with a few seconds of work before `it2check` was executed - enough time for the user to "accidentally" enter pending input.

Here's a simplified reproduction (`sleep 2` stands in for any amount of other work).

In `iTerm.app` (from the root of this repository):
```shell
# Run as usual - no pending input when `it2check` executes. Woohoo!
$ sleep 2; ./it2check && echo "iTerm2" || echo "Not iTerm2"
iTerm2

# Enter anything on stdin before `it2check` executes. Oh no!
$ sleep 2; ./it2check && echo "iTerm2" || echo "Not iTerm2"
pending inputNot iTerm2
$ g inputTERM2 3.4.15nn
```
The pending input was consumed up to and including the first `n` after the first two characters. What's more, the DSR response wasn't consumed and still appears on stdin once the TTY is reset.

Even worse, in e.g. `Terminal.app` (or any terminal that doesn't respond to DSR 1337):
```shell
# Run as usual - no pending input when `it2check` executes. Woohoo!
$ sleep 2; ./it2check && echo "iTerm2" || echo "Not iTerm2"
Not iTerm2

# Enter anything on stdin before `it2check` executes. Oh no!
$ sleep 2; ./it2check && echo "iTerm2" || echo "Not iTerm2"
text without the letter after m
... # `it2check` hangs executing `dd`. :( To break out, enter any two characters and then `n`.
```

The `read_dsr` function seems to assumes that there is no pending input on stdin besides the DSR responses generated by DSR 1337 and DSR 5. However, if there is any pending input, `read_dsr` incorrectly attempts to parse the pending input as DSR response information and fails.

Even more confusingly for an end user in e.g. `Terminal.app`, whether or not it hangs depends on whether there are any `n`s in the pending input (which usually signify the end of a DSR response), as well as where the `n`s occur (indices 0 and 1 are skipped as DSR response spam).

This hotfix, which just consumes all pending input within the `it2check` script, might not be the best solution (ideally, pending input would remain untouched and `it2check` and the terminal could just talk on a side channel), and it still has some debugging notes in it (it doesn't need to clean up when we're about to reset the terminal settings again), but it resolves the problems described above. Basically, [anything that clears stdin before reading](https://superuser.com/questions/276531/clear-stdin-before-reading) would be fine, and I'm not attached to this implementation at all. After this change:

```shell
# In `iTerm.app`
$ sleep 2; ./it2check && echo "iTerm2" || echo "Not iTerm2"
pending inputiTerm2
# In `Terminal.app`
$ sleep 2; ./it2check && echo "iTerm2" || echo "Not iTerm2"
some textNot iTerm2
```

In case it's worth knowing, I've been testing this on `GNU bash, version 5.1.16(1)-release (x86_64-apple-darwin21.1.0)` on macOS 12.3.1.