### PR TITLE
it2profile: Fixing issues with stty

### DIFF
--- a/utilities/it2profile
+++ b/utilities/it2profile
@@ -94,14 +94,14 @@ function check_dependency() {
 #
 function get_profile() {
     trap 'cleanup' EXIT
-    stty -f /dev/tty -echo 2&> /dev/null || stty -F /dev/tty -echo
+    stty -echo < /dev/tty
     exec 9<> /dev/tty
     print_osc >&9
     printf "1337;ReportVariable=cHJvZmlsZU5hbWU=" >&9
     print_st >&9
     read -r -t 5 -d $'\a' iterm_response <&9
     exec 9>&-
-    stty -f /dev/tty -echo 2&> /dev/null || stty -F /dev/tty -echo
+    stty echo < /dev/tty
     [[ "$iterm_response" =~ ReportVariable= ]] || {
         error "Failed to read response from iTerm2"
         exit 2
@@ -110,7 +110,7 @@ function get_profile() {
 }
 
 function cleanup() {
-    stty -f /dev/tty echo 2&> /dev/null || stty -F /dev/tty echo
+    stty echo < /dev/tty
 }
 
 function set_profile() {
@@ -164,7 +164,7 @@ case "$1" in
         error "Unknown option: $1"
         show_help
         exit 1
-      ;;
+        ;;
 esac
 
 exit 0


### PR DESCRIPTION
This all about this code that has issues:

```bash
stty -f /dev/tty -echo 2&> /dev/null || stty -F /dev/tty -echo
```
1. Redirection should be `&> /dev/null` or `>/dev/null 2>&1`. String `2&>` as above is considered by bash as argument `2` followed by redirection `&>`. So it leads to that stty sets terminal speed to 2 baud.
2. Redirecting STDIN to /dev/tty is more simplest way to get rid of `-f` or `-F` option to be BSD and Linux compatible.
3. There is a simple copy-paste error, there should be `stty -echo` followed by `stty echo`.
