### PR TITLE
Add missing added and deleted variables for it2git

### DIFF
--- a/utilities/it2git
+++ b/utilities/it2git
@@ -93,6 +93,8 @@ git_poll () {
     PUSH_COUNT=$(cut -f1 <<< "$COUNTS")
     PULL_COUNT=$(cut -f2 <<< "$COUNTS")
     BRANCH=$(branch)
+    ADDS=$(adds)
+    DELETES=$(deletes)
 
     iterm2_set_user_var gitBranch "$BRANCH"
     iterm2_set_user_var gitDirty "$DIRTY"


### PR DESCRIPTION
`gitAdds` and `gitDeletes` user vars were being set using variables that were never declared, though functions for getting them are present.